### PR TITLE
Remove duplicate "Start torrent" checkbox in "Add torrent" dialog.

### DIFF
--- a/src/gui/addnewtorrentdialog.ui
+++ b/src/gui/addnewtorrentdialog.ui
@@ -192,16 +192,6 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="startTorrentCheckBox_2">
-        <property name="text">
-         <string>Start torrent</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QCheckBox" name="createSubfolderCheckBox">
         <property name="text">


### PR DESCRIPTION
This removes a dummy duplicate "Start torrent" checkbox (introduced in
4b2d8a7, renamed in 22178f9) which was displayed on top of the real one,
preventing any interaction with it.