### PR TITLE
Fix localhost login if auth bypass enabled

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -181,7 +181,7 @@ void WebApplication::action_public_login()
     bool equalUser = Utils::String::slowEquals(request().posts["username"].toUtf8(), pref->getWebUiUsername().toUtf8());
     bool equalPass = Utils::String::slowEquals(pass.toUtf8(), pref->getWebUiPassword().toUtf8());
 
-    if (equalUser && equalPass) {
+    if ((equalUser && equalPass) || !isAuthNeeded()) {
         sessionStart();
         print(QByteArray("Ok."), Http::CONTENT_TYPE_TXT);
     }


### PR DESCRIPTION
If "Bypass authentication for localhost" is enabled and a local application misbehaves by attempting authentication with the WebUI API using a blank or incorrect password, login should still be allowed.