### PR TITLE
Keep a list of individual trackers for each (host,hash) pair. Closes …

### DIFF
--- a/src/gui/transferlistfilterswidget.h
+++ b/src/gui/transferlistfilterswidget.h
@@ -127,7 +127,7 @@ private:
     void downloadFavicon(const QString &url);
 
 private:
-    QHash<QString, QStringList> m_trackers;
+    QHash<QString, QHash<QString, QStringList>> m_trackers;
     QHash<QString, QStringList> m_errors;
     QHash<QString, QStringList> m_warnings;
     QStringList m_iconPaths;


### PR DESCRIPTION
…#4267.

If the tracker list for a torrent includes several entries pointing to
the same host, removing a single entry should not immediately cause the
(host,torrent) item to disappear from the tracker filters list.

By keeping a list of all actual tracker URLs for each (host,hash) pair,
we can determine whether or not a removed entry was the last one
remaining.