### PR TITLE
Replace dialog ok-cancel buttons with QDialogButtonBox

### DIFF
--- a/src/gui/downloadfromurldlg.h
+++ b/src/gui/downloadfromurldlg.h
@@ -31,22 +31,30 @@
 #ifndef DOWNLOADFROMURL_H
 #define DOWNLOADFROMURL_H
 
+#include <QClipboard>
 #include <QDialog>
 #include <QMessageBox>
-#include <QString>
+#include <QPushButton>
 #include <QRegExp>
+#include <QString>
 #include <QStringList>
-#include <QClipboard>
+
 #include "ui_downloadfromurldlg.h"
 
-class downloadFromURL : public QDialog, private Ui::downloadFromURL{
+class downloadFromURL : public QDialog, private Ui::downloadFromURL
+{
   Q_OBJECT
 
   public:
-    downloadFromURL(QWidget *parent): QDialog(parent) {
+    downloadFromURL(QWidget *parent): QDialog(parent)
+    {
       setupUi(this);
       setAttribute(Qt::WA_DeleteOnClose);
       setModal(true);
+
+      buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Download"));
+      connect(buttonBox, &QDialogButtonBox::accepted, this, &downloadFromURL::downloadButtonClicked);
+      connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
       // Paste clipboard if there is an URL in it
       QString clip_txt = qApp->clipboard()->text();
@@ -80,8 +88,9 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
   signals:
     void urlsReadyToBeDownloaded(const QStringList& torrent_urls);
 
-  public slots:
-    void on_downloadButton_clicked() {
+  private slots:
+    void downloadButtonClicked()
+    {
       QString urls = textUrls->toPlainText();
       QStringList url_list = urls.split(QString::fromUtf8("\n"));
       QString url;
@@ -100,11 +109,7 @@ class downloadFromURL : public QDialog, private Ui::downloadFromURL{
       }
       emit urlsReadyToBeDownloaded(url_list_cleaned);
       qDebug("Emitted urlsReadytobedownloaded signal");
-      close();
-    }
-
-    void on_cancelButton_clicked() {
-      close();
+      accept();
     }
 };
 

--- a/src/gui/downloadfromurldlg.ui
+++ b/src/gui/downloadfromurldlg.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>482</width>
+    <width>501</width>
     <height>220</height>
    </rect>
   </property>
@@ -50,48 +50,14 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="downloadButton">
-       <property name="text">
-        <string>Download</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/gui/login.ui
+++ b/src/gui/login.ui
@@ -134,85 +134,19 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="loginButton">
-       <property name="text">
-        <string>Log in</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <resources/>
  <connections>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>authentication</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>245</x>
-     <y>195</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>179</x>
-     <y>230</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>linePasswd</sender>
-   <signal>returnPressed()</signal>
-   <receiver>loginButton</receiver>
-   <slot>click()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>139</x>
-     <y>158</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>122</x>
-     <y>199</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>lineUsername</sender>
    <signal>returnPressed()</signal>

--- a/src/gui/preview.ui
+++ b/src/gui/preview.ui
@@ -32,68 +32,17 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="previewButton">
-       <property name="text">
-        <string>Preview</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancelButton">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>preview</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>296</x>
-     <y>245</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>179</x>
-     <y>282</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/gui/previewselect.cpp
+++ b/src/gui/previewselect.cpp
@@ -31,6 +31,7 @@
 #include <QFile>
 #include <QHeaderView>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QStandardItemModel>
 #include <QTableView>
 
@@ -45,6 +46,11 @@ PreviewSelect::PreviewSelect(QWidget* parent, BitTorrent::TorrentHandle *const t
 {
     setupUi(this);
     setAttribute(Qt::WA_DeleteOnClose);
+
+    buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Preview"));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &PreviewSelect::previewButtonClicked);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
     Preferences *const pref = Preferences::instance();
     // Preview list
     m_previewListModel = new QStandardItemModel(0, NB_COLUMNS);
@@ -95,7 +101,7 @@ PreviewSelect::PreviewSelect(QWidget* parent, BitTorrent::TorrentHandle *const t
     if (m_previewListModel->rowCount() == 1) {
         qDebug("Torrent file only contains one file, no need to display selection dialog before preview");
         // Only one file : no choice
-        on_previewButton_clicked();
+        previewButtonClicked();
     }
     else {
         qDebug("Displaying media file selection dialog for preview");
@@ -110,7 +116,7 @@ PreviewSelect::~PreviewSelect()
 }
 
 
-void PreviewSelect::on_previewButton_clicked()
+void PreviewSelect::previewButtonClicked()
 {
     QModelIndexList selectedIndexes = previewList->selectionModel()->selectedRows(FILE_INDEX);
     if (selectedIndexes.size() == 0) return;
@@ -127,10 +133,5 @@ void PreviewSelect::on_previewButton_clicked()
     else
         QMessageBox::critical(this->parentWidget(), tr("Preview impossible"), tr("Sorry, we can't preview this file"));
 
-    close();
-}
-
-void PreviewSelect::on_cancelButton_clicked()
-{
-    close();
+    accept();
 }

--- a/src/gui/previewselect.h
+++ b/src/gui/previewselect.h
@@ -39,7 +39,7 @@ class QStandardItemModel;
 
 class PreviewListDelegate;
 
-class PreviewSelect: public QDialog, private Ui::preview
+class PreviewSelect : public QDialog, private Ui::preview
 {
     Q_OBJECT
 
@@ -60,9 +60,8 @@ public:
 signals:
     void readyToPreviewFile(QString) const;
 
-protected slots:
-    void on_previewButton_clicked();
-    void on_cancelButton_clicked();
+private slots:
+    void previewButtonClicked();
 
 private:
     QStandardItemModel *m_previewListModel;

--- a/src/gui/trackerlogin.h
+++ b/src/gui/trackerlogin.h
@@ -53,9 +53,9 @@ class trackerLogin : public QDialog, private Ui::authentication{
   signals:
     void trackerLoginCancelled(QPair<BitTorrent::TorrentHandle*, QString> tracker);
 
-  public slots:
-    void on_loginButton_clicked();
-    void on_cancelButton_clicked();
+  private slots:
+    void loginButtonClicked();
+    void cancelButtonClicked();
 };
 
 #endif


### PR DESCRIPTION
This PR will make button order follow the platform default.
For example: windows use: OK, Cancel; linux use: Cancel, OK.