### PR TITLE
Don't implicitly cast iterator to const_iterator

### DIFF
--- a/src/base/scanfoldersmodel.cpp
+++ b/src/base/scanfoldersmodel.cpp
@@ -340,7 +340,7 @@ void ScanFoldersModel::makePersistent()
 
 void ScanFoldersModel::configure()
 {
-    QVariantHash dirs = Preferences::instance()->getScanDirs();
+    const QVariantHash dirs = Preferences::instance()->getScanDirs();
 
     for (QVariantHash::const_iterator i = dirs.begin(), e = dirs.end(); i != e; ++i) {
         if (i.value().type() == QVariant::Int)

--- a/src/gui/torrentcontenttreeview.cpp
+++ b/src/gui/torrentcontenttreeview.cpp
@@ -66,7 +66,7 @@ void TorrentContentTreeView::keyPressEvent(QKeyEvent *event)
     Qt::CheckState state = (static_cast<Qt::CheckState>(value.toInt()) == Qt::Checked
                             ? Qt::Unchecked : Qt::Checked);
 
-    QModelIndexList selection = selectionModel()->selectedRows(TorrentContentModelItem::COL_NAME);
+    const QModelIndexList selection = selectionModel()->selectedRows(TorrentContentModelItem::COL_NAME);
 
     for (QModelIndexList::const_iterator i = selection.begin(); i != selection.end(); ++i) {
         QModelIndex index = *i;

--- a/src/src.pro
+++ b/src/src.pro
@@ -57,6 +57,7 @@ include(../version.pri)
 DEFINES += QT_NO_CAST_TO_ASCII
 # Efficient construction for QString & QByteArray (Qt >= 4.8)
 DEFINES += QT_USE_QSTRINGBUILDER
+DEFINES += QT_STRICT_ITERATORS
 
 INCLUDEPATH += $$PWD
 

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -88,7 +88,7 @@ void AppController::preferencesAction()
     data["temp_path"] = Utils::Fs::toNativePath(session->tempPath());
     data["preallocate_all"] = session->isPreallocationEnabled();
     data["incomplete_files_ext"] = session->isAppendExtensionEnabled();
-    QVariantHash dirs = pref->getScanDirs();
+    const QVariantHash dirs = pref->getScanDirs();
     QVariantMap nativeDirs;
     for (QVariantHash::const_iterator i = dirs.begin(), e = dirs.end(); i != e; ++i) {
         if (i.value().type() == QVariant::Int)
@@ -240,7 +240,7 @@ void AppController::setPreferencesAction()
     if (m.contains("incomplete_files_ext"))
         session->setAppendExtensionEnabled(m["incomplete_files_ext"].toBool());
     if (m.contains("scan_dirs")) {
-        QVariantMap nativeDirs = m["scan_dirs"].toMap();
+        const QVariantMap nativeDirs = m["scan_dirs"].toMap();
         QVariantHash oldScanDirs = pref->getScanDirs();
         QVariantHash scanDirs;
         ScanFoldersModel *model = ScanFoldersModel::instance();


### PR DESCRIPTION
It prevents detachments:
To illustrate:

QMap<QString, QString> map;
/* code compiles and works fine but find() returns the non-const
   QMap::iterator that detaches!
*/
QMap<QString, QString>::const_iterator it = map.find("girish");

but also some subtle bugs:

QHash<int, int> wrong;
if (wrong.find(1) == wrong.cend()) {
    qDebug() << "Not found";
} else {
    /* find() detached the container before cend() was called, so it
       prints "Found"
    */
    qDebug() << "Found";
}

QHash<int, int> right;
if (right.constFind(1) == right.cend()) {
    qDebug() << "Not found"; // This is correct now !
} else {
    qDebug() << "Found";
}

Enforced by QT_STRICT_ITERATORS definition.