### PR TITLE
Filter torrent info endpoint by hashes

### DIFF
--- a/src/webui/api/torrentscontroller.cpp
+++ b/src/webui/api/torrentscontroller.cpp
@@ -150,6 +150,7 @@ namespace
 // GET params:
 //   - filter (string): all, downloading, seeding, completed, paused, resumed, active, inactive
 //   - category (string): torrent category for filtering by it (empty string means "uncategorized"; no "category" param presented means "any category")
+//   - hashes (string): filter by hashes, can contain multiple hashes separated by |
 //   - sort (string): name of column for sorting by its value
 //   - reverse (bool): enable reverse sorting
 //   - limit (int): set limit number of torrents returned (if greater than 0, otherwise - unlimited)
@@ -162,9 +163,10 @@ void TorrentsController::infoAction()
     const bool reverse {parseBool(params()["reverse"], false)};
     int limit {params()["limit"].toInt()};
     int offset {params()["offset"].toInt()};
+    const QStringSet hashSet {params()["hashes"].split('|', QString::SkipEmptyParts).toSet()};
 
     QVariantList torrentList;
-    TorrentFilter torrentFilter(filter, TorrentFilter::AnyHash, category);
+    TorrentFilter torrentFilter(filter, (hashSet.isEmpty() ? TorrentFilter::AnyHash : hashSet), category);
     foreach (BitTorrent::TorrentHandle *const torrent, BitTorrent::Session::instance()->torrents()) {
         if (torrentFilter.match(torrent))
             torrentList.append(serialize(*torrent));


### PR DESCRIPTION
Added hashes parameter to info action.
Allows filtering seralized torrents by passing it into the TorrentFilter.