### PR TITLE
Improve WebUI security measures

### DIFF
--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -533,10 +533,13 @@ Http::Response WebApplication::processRequest(const Http::Request &request, cons
     header(Http::HEADER_X_XSS_PROTECTION, "1; mode=block");
     header(Http::HEADER_X_CONTENT_TYPE_OPTIONS, "nosniff");
 
+    QString csp = QLatin1String("default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; object-src 'none';");
     if (m_isClickjackingProtectionEnabled) {
         header(Http::HEADER_X_FRAME_OPTIONS, "SAMEORIGIN");
-        header(Http::HEADER_CONTENT_SECURITY_POLICY, "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; object-src 'none';");
+        csp += QLatin1String(" frame-ancestors 'self';");
     }
+
+    header(Http::HEADER_CONTENT_SECURITY_POLICY, csp);
 
     return response();
 }


### PR DESCRIPTION
CSP was erroneously disabled in bad4d94f778a1ceba8a0e16d1836e649d767cca8
when clickjacking protection is off, now it is back.
Also added CSP 'frame-ancestors' directive when clickjacking
protection is enabled.