### PR TITLE
Allow disabled speed limits to be remembered

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -987,7 +987,7 @@ void MainWindow::on_actionSetGlobalUploadLimit_triggered()
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-        this, &ok, tr("Global Upload Speed Limit"), session->uploadSpeedLimit());
+        this, &ok, tr("Global Upload Speed Limit"), qMax(0, session->uploadSpeedLimit()));
 
     if (ok) {
         qDebug("Setting global upload rate limit to %.1fKb/s", newLimit / 1024.);
@@ -1002,7 +1002,7 @@ void MainWindow::on_actionSetGlobalDownloadLimit_triggered()
     BitTorrent::Session *const session = BitTorrent::Session::instance();
     bool ok = false;
     const long newLimit = SpeedLimitDialog::askSpeedLimit(
-        this, &ok, tr("Global Download Speed Limit"), session->downloadSpeedLimit());
+        this, &ok, tr("Global Download Speed Limit"), qMax(0, session->downloadSpeedLimit()));
 
     if (ok) {
         qDebug("Setting global download rate limit to %.1fKb/s", newLimit / 1024.);

--- a/src/gui/optionsdialog.cpp
+++ b/src/gui/optionsdialog.cpp
@@ -643,15 +643,17 @@ void OptionsDialog::saveOptions()
     session->setPort(getPort());
     session->setUseRandomPort(m_ui->checkRandomPort->isChecked());
     Net::PortForwarder::instance()->setEnabled(isUPnPEnabled());
-    const QPair<int, int> downUpLimit = getGlobalBandwidthLimits();
-    session->setGlobalDownloadSpeedLimit(downUpLimit.first);
-    session->setGlobalUploadSpeedLimit(downUpLimit.second);
+    session->setGlobalDownloadSpeedLimit(m_ui->spinDownloadLimit->value() * 1024
+        * (m_ui->checkDownloadLimit->isChecked() ? 1 : -1));
+    session->setGlobalUploadSpeedLimit(m_ui->spinUploadLimit->value() * 1024
+        * (m_ui->checkUploadLimit->isChecked() ? 1 : -1));
+    session->setAltGlobalDownloadSpeedLimit(m_ui->spinDownloadLimitAlt->value() * 1024
+        * (m_ui->checkDownloadLimitAlt->isChecked() ? 1 : -1));
+    session->setAltGlobalUploadSpeedLimit(m_ui->spinUploadLimitAlt->value() * 1024
+        * (m_ui->checkUploadLimitAlt->isChecked() ? 1 : -1));
     session->setUTPRateLimited(m_ui->checkLimituTPConnections->isChecked());
     session->setIncludeOverheadInLimits(m_ui->checkLimitTransportOverhead->isChecked());
     session->setIgnoreLimitsOnLAN(!m_ui->checkLimitLocalPeerRate->isChecked());
-    const QPair<int, int> altDownUpLimit = getAltGlobalBandwidthLimits();
-    session->setAltGlobalDownloadSpeedLimit(altDownUpLimit.first);
-    session->setAltGlobalUploadSpeedLimit(altDownUpLimit.second);
     pref->setSchedulerStartTime(m_ui->timeEditScheduleFrom->time());
     pref->setSchedulerEndTime(m_ui->timeEditScheduleTo->time());
     pref->setSchedulerDays(static_cast<SchedulerDays>(m_ui->comboBoxScheduleDays->currentIndex()));
@@ -1010,52 +1012,40 @@ void OptionsDialog::loadOptions()
     // End Connection preferences
 
     // Speed preferences
-    intValue = session->globalDownloadSpeedLimit() / 1024;
-    if (intValue > 0) {
-        // Enabled
+    m_ui->spinDownloadLimit->setValue(qAbs(session->globalDownloadSpeedLimit() / 1024));
+    if (session->globalDownloadSpeedLimit() > 0) {
         m_ui->checkDownloadLimit->setChecked(true);
         m_ui->spinDownloadLimit->setEnabled(true);
-        m_ui->spinDownloadLimit->setValue(intValue);
     }
     else {
-        // Disabled
         m_ui->checkDownloadLimit->setChecked(false);
         m_ui->spinDownloadLimit->setEnabled(false);
     }
-    intValue = session->globalUploadSpeedLimit() / 1024;
-    if (intValue > 0) {
-        // Enabled
+    m_ui->spinUploadLimit->setValue(qAbs(session->globalUploadSpeedLimit() / 1024));
+    if (session->globalUploadSpeedLimit() > 0) {
         m_ui->checkUploadLimit->setChecked(true);
         m_ui->spinUploadLimit->setEnabled(true);
-        m_ui->spinUploadLimit->setValue(intValue);
     }
     else {
-        // Disabled
         m_ui->checkUploadLimit->setChecked(false);
         m_ui->spinUploadLimit->setEnabled(false);
     }
 
-    intValue = session->altGlobalDownloadSpeedLimit() / 1024;
-    if (intValue > 0) {
-        // Enabled
+    m_ui->spinDownloadLimitAlt->setValue(qAbs(session->altGlobalDownloadSpeedLimit() / 1024));
+    if (session->altGlobalDownloadSpeedLimit() > 0) {
         m_ui->checkDownloadLimitAlt->setChecked(true);
         m_ui->spinDownloadLimitAlt->setEnabled(true);
-        m_ui->spinDownloadLimitAlt->setValue(intValue);
     }
     else {
-        // Disabled
         m_ui->checkDownloadLimitAlt->setChecked(false);
         m_ui->spinDownloadLimitAlt->setEnabled(false);
     }
-    intValue = session->altGlobalUploadSpeedLimit() / 1024;
-    if (intValue > 0) {
-        // Enabled
+    m_ui->spinUploadLimitAlt->setValue(qAbs(session->altGlobalUploadSpeedLimit() / 1024));
+    if (session->altGlobalUploadSpeedLimit() > 0) {
         m_ui->checkUploadLimitAlt->setChecked(true);
         m_ui->spinUploadLimitAlt->setEnabled(true);
-        m_ui->spinUploadLimitAlt->setValue(intValue);
     }
     else {
-        // Disabled
         m_ui->checkUploadLimitAlt->setChecked(false);
         m_ui->spinUploadLimitAlt->setEnabled(false);
     }
@@ -1196,30 +1186,6 @@ bool OptionsDialog::isLSDEnabled() const
 bool OptionsDialog::isUPnPEnabled() const
 {
     return m_ui->checkUPnP->isChecked();
-}
-
-// Return Download & Upload limits in kbps
-// [download,upload]
-QPair<int, int> OptionsDialog::getGlobalBandwidthLimits() const
-{
-    int DL = 0, UP = 0;
-    if (m_ui->checkDownloadLimit->isChecked())
-        DL = m_ui->spinDownloadLimit->value() * 1024;
-    if (m_ui->checkUploadLimit->isChecked())
-        UP = m_ui->spinUploadLimit->value() * 1024;
-    return qMakePair(DL, UP);
-}
-
-// Return alternate Download & Upload limits in kbps
-// [download,upload]
-QPair<int, int> OptionsDialog::getAltGlobalBandwidthLimits() const
-{
-    int DL = 0, UP = 0;
-    if (m_ui->checkDownloadLimitAlt->isChecked())
-        DL = m_ui->spinDownloadLimitAlt->value() * 1024;
-    if (m_ui->checkUploadLimitAlt->isChecked())
-        UP = m_ui->spinUploadLimitAlt->value() * 1024;
-    return qMakePair(DL, UP);
 }
 
 bool OptionsDialog::startMinimized() const

--- a/src/gui/optionsdialog.h
+++ b/src/gui/optionsdialog.h
@@ -137,8 +137,6 @@ private:
     // Connection options
     int getPort() const;
     bool isUPnPEnabled() const;
-    QPair<int, int> getGlobalBandwidthLimits() const;
-    QPair<int, int> getAltGlobalBandwidthLimits() const;
     // Bittorrent options
     int getMaxConnecs() const;
     int getMaxConnecsPerTorrent() const;

--- a/src/gui/statusbar.cpp
+++ b/src/gui/statusbar.cpp
@@ -206,18 +206,19 @@ void StatusBar::updateSpeedLabels()
 {
     const BitTorrent::SessionStatus &sessionStatus = BitTorrent::Session::instance()->status();
 
-    QString speedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadDownloadRate, true);
-    int speedLimit = BitTorrent::Session::instance()->downloadSpeedLimit();
-    if (speedLimit)
-        speedLbl += " [" + Utils::Misc::friendlyUnit(speedLimit, true) + ']';
-    speedLbl += " (" + Utils::Misc::friendlyUnit(sessionStatus.totalPayloadDownload) + ')';
-    m_dlSpeedLbl->setText(speedLbl);
-    speedLimit = BitTorrent::Session::instance()->uploadSpeedLimit();
-    speedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadUploadRate, true);
-    if (speedLimit)
-        speedLbl += " [" + Utils::Misc::friendlyUnit(speedLimit, true) + ']';
-    speedLbl += " (" + Utils::Misc::friendlyUnit(sessionStatus.totalPayloadUpload) + ')';
-    m_upSpeedLbl->setText(speedLbl);
+    QString dlSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadDownloadRate, true);
+    const int dlSpeedLimit = BitTorrent::Session::instance()->downloadSpeedLimit();
+    if (dlSpeedLimit > 0)
+        dlSpeedLbl += " [" + Utils::Misc::friendlyUnit(dlSpeedLimit, true) + ']';
+    dlSpeedLbl += " (" + Utils::Misc::friendlyUnit(sessionStatus.totalPayloadDownload) + ')';
+    m_dlSpeedLbl->setText(dlSpeedLbl);
+
+    QString upSpeedLbl = Utils::Misc::friendlyUnit(sessionStatus.payloadUploadRate, true);
+    const int upSpeedLimit = BitTorrent::Session::instance()->uploadSpeedLimit();
+    if (upSpeedLimit > 0)
+        upSpeedLbl += " [" + Utils::Misc::friendlyUnit(upSpeedLimit, true) + ']';
+    upSpeedLbl += " (" + Utils::Misc::friendlyUnit(sessionStatus.totalPayloadUpload) + ')';
+    m_upSpeedLbl->setText(upSpeedLbl);
 }
 
 void StatusBar::refresh()

--- a/src/webui/api/appcontroller.cpp
+++ b/src/webui/api/appcontroller.cpp
@@ -147,11 +147,11 @@ void AppController::preferencesAction()
     // Global Rate Limits
     data["dl_limit"] = session->globalDownloadSpeedLimit();
     data["up_limit"] = session->globalUploadSpeedLimit();
+    data["alt_dl_limit"] = session->altGlobalDownloadSpeedLimit();
+    data["alt_up_limit"] = session->altGlobalUploadSpeedLimit();
     data["bittorrent_protocol"] = static_cast<int>(session->btProtocol());
     data["limit_utp_rate"] = session->isUTPRateLimited();
     data["limit_tcp_overhead"] = session->includeOverheadInLimits();
-    data["alt_dl_limit"] = session->altGlobalDownloadSpeedLimit();
-    data["alt_up_limit"] = session->altGlobalUploadSpeedLimit();
     // Scheduling
     data["scheduler_enabled"] = session->isBandwidthSchedulerEnabled();
     const QTime start_time = pref->getSchedulerStartTime();
@@ -368,16 +368,16 @@ void AppController::setPreferencesAction()
         session->setGlobalDownloadSpeedLimit(m["dl_limit"].toInt());
     if (m.contains("up_limit"))
         session->setGlobalUploadSpeedLimit(m["up_limit"].toInt());
+    if (m.contains("alt_dl_limit"))
+        session->setAltGlobalDownloadSpeedLimit(m["alt_dl_limit"].toInt());
+    if (m.contains("alt_up_limit"))
+       session->setAltGlobalUploadSpeedLimit(m["alt_up_limit"].toInt());
     if (m.contains("bittorrent_protocol"))
         session->setBTProtocol(static_cast<BitTorrent::BTProtocol>(m["bittorrent_protocol"].toInt()));
     if (m.contains("limit_utp_rate"))
         session->setUTPRateLimited(m["limit_utp_rate"].toBool());
     if (m.contains("limit_tcp_overhead"))
         session->setIncludeOverheadInLimits(m["limit_tcp_overhead"].toBool());
-    if (m.contains("alt_dl_limit"))
-        session->setAltGlobalDownloadSpeedLimit(m["alt_dl_limit"].toInt());
-    if (m.contains("alt_up_limit"))
-       session->setAltGlobalUploadSpeedLimit(m["alt_up_limit"].toInt());
     // Scheduling
     if (m.contains("scheduler_enabled"))
         session->setBandwidthSchedulerEnabled(m["scheduler_enabled"].toBool());

--- a/src/webui/www/private/preferences_content.html
+++ b/src/webui/www/private/preferences_content.html
@@ -919,46 +919,26 @@
                     // Speed tab
                     // Global Rate Limits
                     var up_limit = pref.up_limit.toInt() / 1024;
-                    if (up_limit <= 0) {
-                        $('up_limit_checkbox').setProperty('checked', false);
-                    }
-                    else {
-                        $('up_limit_checkbox').setProperty('checked', true);
-                        $('up_limit_value').setProperty('value', up_limit);
-                    }
+                    $('up_limit_value').setProperty('value', Math.abs(up_limit));
+                    $('up_limit_checkbox').setProperty('checked', (up_limit > 0));
                     updateUpLimitEnabled();
                     var dl_limit = pref.dl_limit.toInt() / 1024;
-                    if (dl_limit <= 0) {
-                        $('dl_limit_checkbox').setProperty('checked', false);
-                    }
-                    else {
-                        $('dl_limit_checkbox').setProperty('checked', true);
-                        $('dl_limit_value').setProperty('value', dl_limit);
-                    }
+                    $('dl_limit_value').setProperty('value', Math.abs(dl_limit));
+                    $('dl_limit_checkbox').setProperty('checked', (dl_limit > 0));
                     updateDlLimitEnabled();
+                    // Alternative Global Rate Limits
+                    var alt_up_limit = pref.alt_up_limit.toInt() / 1024;
+                    $('alt_up_limit_value').setProperty('value', Math.abs(alt_up_limit));
+                    $('alt_up_limit_checkbox').setProperty('checked', (alt_up_limit > 0));
+                    updateAltUpLimitEnabled();
+                    var alt_dl_limit = pref.alt_dl_limit.toInt() / 1024;
+                    $('alt_dl_limit_value').setProperty('value', Math.abs(alt_dl_limit));
+                    $('alt_dl_limit_checkbox').setProperty('checked', (alt_dl_limit > 0));
+                    updateAltDlLimitEnabled();
+
                     $('enable_protocol_combobox').setProperty('value', pref.bittorrent_protocol);
                     $('limit_utp_rate_checkbox').setProperty('checked', pref.limit_utp_rate);
                     $('limit_tcp_overhead_checkbox').setProperty('checked', pref.limit_tcp_overhead);
-
-                    // Alternative Global Rate Limits
-                    var alt_up_limit = pref.alt_up_limit.toInt() / 1024;
-                    if (alt_up_limit <= 0) {
-                        $('alt_up_limit_checkbox').setProperty('checked', false);
-                    }
-                    else {
-                        $('alt_up_limit_checkbox').setProperty('checked', true);
-                        $('alt_up_limit_value').setProperty('value', alt_up_limit);
-                    }
-                    updateAltUpLimitEnabled();
-                    var alt_dl_limit = pref.alt_dl_limit.toInt() / 1024;
-                    if (alt_dl_limit <= 0) {
-                        $('alt_dl_limit_checkbox').setProperty('checked', false);
-                    }
-                    else {
-                        $('alt_dl_limit_checkbox').setProperty('checked', true);
-                        $('alt_dl_limit_value').setProperty('value', alt_dl_limit);
-                    }
-                    updateAltDlLimitEnabled();
 
                     // Scheduling
                     $('limit_sheduling_checkbox').setProperty('checked', pref.scheduler_enabled);
@@ -1175,47 +1155,38 @@
 
         // Speed tab
         // Global Rate Limits
-        var up_limit = -1;
-        if ($('up_limit_checkbox').getProperty('checked')) {
-            up_limit = $('up_limit_value').getProperty('value').toInt() * 1024;
-            if (isNaN(up_limit) || up_limit <= 0) {
-                alert("QBT_TR(Global upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
+        var up_limit = $('up_limit_value').getProperty('value').toInt() * 1024;
+        if (isNaN(up_limit) || up_limit <= 0) {
+            alert("QBT_TR(Global upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+            return;
         }
-        settings.set('up_limit', up_limit);
-        var dl_limit = -1;
-        if ($('dl_limit_checkbox').getProperty('checked')) {
-            dl_limit = $('dl_limit_value').getProperty('value').toInt() * 1024;
-            if (isNaN(dl_limit) || dl_limit <= 0) {
-                alert("QBT_TR(Global download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
+        settings.set('up_limit', (up_limit * ($('up_limit_checkbox').getProperty('checked') ? 1 : -1)));
+
+        var dl_limit = $('dl_limit_value').getProperty('value').toInt() * 1024;
+        if (isNaN(dl_limit) || dl_limit <= 0) {
+            alert("QBT_TR(Global download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+            return;
         }
-        settings.set('dl_limit', dl_limit);
+        settings.set('dl_limit', (dl_limit * ($('dl_limit_checkbox').getProperty('checked') ? 1 : -1)));
+
+        // Alternative Global Rate Limits
+        var alt_up_limit = $('alt_up_limit_value').getProperty('value').toInt() * 1024;
+        if (isNaN(alt_up_limit) || alt_up_limit <= 0) {
+            alert("QBT_TR(Alternative upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+            return;
+        }
+        settings.set('alt_up_limit', (alt_up_limit * ($('alt_up_limit_checkbox').getProperty('checked') ? 1 : -1)));
+
+        var alt_dl_limit = $('alt_dl_limit_value').getProperty('value').toInt() * 1024;
+        if (isNaN(alt_dl_limit) || alt_dl_limit <= 0) {
+            alert("QBT_TR(Alternative download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
+            return;
+        }
+        settings.set('alt_dl_limit', (alt_dl_limit * ($('alt_dl_limit_checkbox').getProperty('checked') ? 1 : -1)));
+
         settings.set('bittorrent_protocol', $('enable_protocol_combobox').getProperty('value'));
         settings.set('limit_utp_rate', $('limit_utp_rate_checkbox').getProperty('checked'));
         settings.set('limit_tcp_overhead', $('limit_tcp_overhead_checkbox').getProperty('checked'));
-
-        // Alternative Global Rate Limits
-        var alt_up_limit = -1;
-        if ($('alt_up_limit_checkbox').getProperty('checked')) {
-            alt_up_limit = $('alt_up_limit_value').getProperty('value').toInt() * 1024;
-            if (isNaN(alt_up_limit) || alt_up_limit <= 0) {
-                alert("QBT_TR(Alternative upload rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
-        }
-        settings.set('alt_up_limit', alt_up_limit);
-        var alt_dl_limit = -1;
-        if ($('alt_dl_limit_checkbox').getProperty('checked')) {
-            alt_dl_limit = $('alt_dl_limit_value').getProperty('value').toInt() * 1024;
-            if (isNaN(alt_dl_limit) || alt_dl_limit <= 0) {
-                alert("QBT_TR(Alternative download rate limit must be greater than 0 or disabled.)QBT_TR[CONTEXT=HttpServer]");
-                return;
-            }
-        }
-        settings.set('alt_dl_limit', alt_dl_limit);
 
         // Scheduler
         var scheduling_enabled = $('limit_sheduling_checkbox').getProperty('checked');


### PR DESCRIPTION
Before this patch, when a speed limit is disabled (checkbox unchecked)
the previous limit value is lost.
This patch fixes the issue by storing the limit in negative value when
disabled.

Fixes #9685.