### PR TITLE
Draw progress bar in Fusion style on macOS systems

### DIFF
--- a/src/gui/previewlistdelegate.h
+++ b/src/gui/previewlistdelegate.h
@@ -36,7 +36,7 @@
 #include <QStyleOptionProgressBar>
 #include <QStyleOptionViewItem>
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 #include <QProxyStyle>
 #endif
 
@@ -76,7 +76,7 @@ public:
                 newopt.minimum = 0;
                 newopt.state |= QStyle::State_Enabled;
                 newopt.textVisible = true;
-#ifndef Q_OS_WIN
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
                 QApplication::style()->drawControl(QStyle::CE_ProgressBar, &newopt, painter);
 #else
                 // XXX: To avoid having the progress text on the right of the bar

--- a/src/gui/properties/proplistdelegate.cpp
+++ b/src/gui/properties/proplistdelegate.cpp
@@ -36,7 +36,7 @@
 #include <QProgressBar>
 #include <QStyleOptionProgressBar>
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 #include <QProxyStyle>
 #endif
 
@@ -101,7 +101,7 @@ void PropListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opti
                 newopt.state |= QStyle::State_Enabled;
             }
 
-#ifndef Q_OS_WIN
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
             QApplication::style()->drawControl(QStyle::CE_ProgressBar, &newopt, painter);
 #else
             // XXX: To avoid having the progress text on the right of the bar

--- a/src/gui/transferlistdelegate.cpp
+++ b/src/gui/transferlistdelegate.cpp
@@ -33,7 +33,7 @@
 #include <QPainter>
 #include <QStyleOptionViewItem>
 
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 #include <QProxyStyle>
 #endif
 
@@ -166,7 +166,7 @@ void TransferListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
             newopt.minimum = 0;
             newopt.state |= QStyle::State_Enabled;
             newopt.textVisible = true;
-#ifndef Q_OS_WIN
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MACOS)
             QApplication::style()->drawControl(QStyle::CE_ProgressBar, &newopt, painter);
 #else
             // XXX: To avoid having the progress text on the right of the bar


### PR DESCRIPTION
Qt has a bug QTBUG-72558, which leads to incorrect progress bar
position, when drawing it in delegate.
Also, since OS X 10.10 Yosemite macOS default style was changed,
and progress bars became very tiny and without text (percentage).
These two cases make qBittorrent look pretty awful, but drawing
progress bar in Fusion style solves both issues.